### PR TITLE
add a patch to fix a python 3.10 deprecation warning

### DIFF
--- a/dropbox-python3.10.patch
+++ b/dropbox-python3.10.patch
@@ -1,0 +1,12 @@
+diff -ur nautilus-dropbox-2020.03.04/dropbox.in nautilus-dropbox-2020.03.04-python3.10/dropbox.in
+--- nautilus-dropbox-2020.03.04/dropbox.in	2020-03-04 23:49:25.000000000 +0100
++++ nautilus-dropbox-2020.03.04-python3.10/dropbox.in	2022-06-22 13:51:30.818855370 +0200
+@@ -611,7 +611,7 @@
+         first = True
+         while True:
+             self.stop_event.wait(0.25)
+-            if self.stop_event.isSet(): break
++            if self.stop_event.is_set(): break
+             if i == len(ticks):
+                 first = False
+                 i = 0

--- a/nautilus-dropbox.spec
+++ b/nautilus-dropbox.spec
@@ -1,7 +1,7 @@
 Name:           nautilus-dropbox
 Epoch:          1
 Version:        2020.03.04
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Dropbox extension for Nautilus
 License:        GPLv3+
 URL:            https://www.dropbox.com
@@ -10,6 +10,8 @@ Source:         https://linux.dropbox.com/packages/%{name}-%{version}.tar.bz2
 # add 10 second delay to autostart to ensure it loads on session startup
 Patch0:         add_startup_delay.patch
 Patch1:         fix_nautilus_includes.patch
+# isSet() deprecation warning from python3.10, the replacement is_set() is available since python3.3
+Patch2:         dropbox-python3.10.patch
 
 ExclusiveArch:  i686 x86_64
 
@@ -67,6 +69,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/dropbox.desktop
 
 
 %changelog
+* Wed Jul 13 2022 Moritz Barsnick <barsnick@gmx.net> - 1:2020.03.04-5
+- add a patch to fix a python 3.10 deprecation warning
+
 * Thu Feb 10 2022 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 1:2020.03.04-4
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
 


### PR DESCRIPTION
Use of isSet() produces a deprecation warning since Python3.10. The replacement
is_set() is available since Python3.3.